### PR TITLE
added c++17 string_view support

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -382,6 +382,7 @@ _CPP_HEADERS = frozenset([
     'stdexcept',
     'streambuf',
     'string',
+    'string_view',
     'strstream',
     'system_error',
     'thread',


### PR DESCRIPTION
cpplint recognizes the C++ 17 standard `string_view` header as a C header and thus raises an `include_order` error.
This will fix the error.